### PR TITLE
add support for php7.2

### DIFF
--- a/src/PSCWS4.php
+++ b/src/PSCWS4.php
@@ -314,7 +314,12 @@ class PSCWS4 {
         // restore the offset
         $this->_off = $off;
         // sort it & return
-        $cmp_func = create_function('$a,$b', 'return ($b[\'weight\'] > $a[\'weight\'] ? 1 : -1);');
+        if ( (float)substr(PHP_VERSION, 0, 3) >= 5.3 ) {
+            $cmp_func = function($a, $b) {return ($b['weight'] > $a['weight'] ? 1 : -1);};
+        } else {
+            $cmp_func = create_function('$a,$b', 'return ($b[\'weight\'] > $a[\'weight\'] ? 1 : -1);');
+        }
+
         usort($list, $cmp_func);
         if (count($list) > $limit) $list = array_slice($list, 0, $limit);
         return $list;


### PR DESCRIPTION
issue:
create_function() method has been DEPRECATED after php7.2.

solution:
When PHP_VERSION over 5.3, using anonymous function instead of it.